### PR TITLE
require as special construct can cause conflicts

### DIFF
--- a/zetalibrary/parser.py
+++ b/zetalibrary/parser.py
@@ -109,7 +109,7 @@ class SCSSParser(CSSParser):
 
 
 class JSParser(Parser):
-    import_re = re.compile(r'^require\(\s*[\'\"]([^\'\"]+)[\'\"]\s*\)\s*;?\s*$', re.MULTILINE)
+    import_re = re.compile(r'^(?:require|include)\(\s*[\'\"]([^\'\"]+)[\'\"]\s*\)\s*;?\s*$', re.MULTILINE)
     comment_re = re.compile(r'/\*(?:[^*]|\*+[^*/])*\*+/')
     comment_template = '// %s\n'
 


### PR DESCRIPTION
`require` function is used in require.js library
`require` is also ambiguous with nodejs' `require`
so I changed regexp to allow usage of `include` in addition to `require`
